### PR TITLE
Add <!DOCTYPE> to head.htm

### DIFF
--- a/partials/site/head.htm
+++ b/partials/site/head.htm
@@ -2,6 +2,7 @@ description = "Head"
 
 [viewBag]
 ==
+<!DOCTYPE html>
 <html lang="en">
 <head>  
     <meta charset="utf-8">


### PR DESCRIPTION
Without specifying doctype, user agent stylesheet add extra margin to forms which breaks the navbar style. Add <!DOCTYPE> tag to head.htm to force html5.